### PR TITLE
Fix missed module inquiry

### DIFF
--- a/src/diag.c
+++ b/src/diag.c
@@ -14,8 +14,9 @@ volatile uint16_t vcc_voltage = 0;
 volatile uint16_t init_vcc = 0xFFFF;
 volatile uint32_t uptime_seconds = 0;
 
-#define DIAG_STEP_VCC_READY 0
-#define DIAG_STEP_VCC_MEASURE 1
+#define DIAG_STEP_VCC_PREPARE 0
+#define DIAG_STEP_VCC_READY 1
+#define DIAG_STEP_VCC_MEASURE 2
 #define DIAG_STEP_OVER 10
 
 volatile uint8_t diag_step = DIAG_STEP_OVER-1;
@@ -36,11 +37,11 @@ void diag_init(void) {
 void diag_update(void) {
 	// called each 100 ms
 	switch (diag_step) {
+	case DIAG_STEP_VCC_PREPARE:
+		vcc_prepare_measure();
+		break;
 	case DIAG_STEP_VCC_READY:
 		adc_start();
-		break;
-	case DIAG_STEP_VCC_MEASURE:
-		vcc_prepare_measure();
 		break;
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -302,9 +302,9 @@ ISR(TIMER2_COMP_vect) {
 	if ((++timer_0) > TIMER_0_MAX) {
 		timer_0 = 0;
 		// Timer 100 Hz (period 10 ms)
-		t3_elapsed = true;
-		if (TCNT0 > 0)
+		if (t3_elapsed) // timer 3 was not processed since last call -> emit warning
 			mtbbus_warn_flags.bits.missed_timer = true;
+		t3_elapsed = true;
 	}
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -298,6 +298,8 @@ static void on_initialized(void) {
 
 ISR(TIMER2_COMP_vect) {
 	// Timer 2 @ 2 kHz (period 500 us)
+	if (inputs_debounce_to_update) // debouncing was not executed since last call -> emit warning
+		mtbbus_warn_flags.bits.missed_timer = true;
 	inputs_debounce_to_update = true;
 	if ((++timer_0) > TIMER_0_MAX) {
 		timer_0 = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -301,6 +301,7 @@ ISR(TIMER2_COMP_vect) {
 	if (inputs_debounce_to_update) // debouncing was not executed since last call -> emit warning
 		mtbbus_warn_flags.bits.missed_timer = true;
 	inputs_debounce_to_update = true;
+
 	if ((++timer_0) > TIMER_0_MAX) {
 		timer_0 = 0;
 		// Timer 100 Hz (period 10 ms)
@@ -312,13 +313,11 @@ ISR(TIMER2_COMP_vect) {
 
 ISR(TIMER0_COMP_vect) {
 	// must be empty, used in libmtb
-
 }
 
 ISR(TIMER1_COMPA_vect) {
 	// must be empty, because bootloader start timer and ISR !
 }
-
 
 ISR(TIMER3_COMPA_vect) {
 	// must be empty, because bootloader start timer and ISR !
@@ -335,6 +334,7 @@ ISR(TIMER1_CAPT_vect) {
 		}
 	}
 }
+
 ISR(TIMER3_CAPT_vect) {
 	uint8_t i;
 	for (i=3; i<6; i++) {
@@ -345,11 +345,6 @@ ISR(TIMER3_CAPT_vect) {
 		}
 	}
 }
-///////////////////////////////////////////////////////////////////////////////
-
-
-
-///////////////////////////////////////////////////////////////////////////////
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/src/main.c
+++ b/src/main.c
@@ -682,11 +682,9 @@ void send_diag_value(uint8_t i) {
 		break;
 
 	case MTBBUS_DV_VMCU:
-		// DEVEL - DEBUG
 		mtbbus_output_buf[0] = 2+2;
-		mtbbus_output_buf[3] = servo_state_target[0];
-		mtbbus_output_buf[4] = servo_state_current[0];
-
+		mtbbus_output_buf[3] = vcc_voltage >> 8;
+		mtbbus_output_buf[4] = vcc_voltage & 0xFF;
 		break;
 
 	case MTBBUS_DV_MTBBUS_RECEIVED:


### PR DESCRIPTION
Make outputs_apply_state faster.

Module had issues with responding to MTB-USB inquiry on time. This was caused by long outputs_apply_state function. Avoid setting of outputs 16 times, prepare output state to local variable, then set all output at once.

Result: MTB-USB does not generate 'module not responded' warnings.